### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,6 @@ license. See the ``LICENSE.txt`` file included for details.
 .. image:: https://travis-ci.org/ddbeck/oraide.png?branch=develop
    :target: https://travis-ci.org/ddbeck/oraide
 
-.. image:: https://pypip.in/v/oraide/badge.png
+.. image:: https://img.shields.io/pypi/v/oraide.svg
    :target: https://crate.io/packages/oraide/
    :alt: Latest Oraide version on PyPI


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20oraide))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `oraide`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.